### PR TITLE
ignore build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+#build output
+src/dep/
+src/obj/
+clang-complete


### PR DESCRIPTION
Added a `.gitignore` file so the build output will not make the repository directory dirty after running `make`.
