### PR TITLE
for bug fix branch

### DIFF
--- a/auto-complete-clang-async.el
+++ b/auto-complete-clang-async.el
@@ -34,7 +34,7 @@
 
 
 (provide 'auto-complete-clang-async)
-(require 'cl)
+(eval-when-compile (require' cl))
 (require 'auto-complete)
 (require 'flymake)
 
@@ -420,7 +420,7 @@ This variable will typically contain include paths, e.g., (\"-I~/MyProject\" \"-
     (process-send-string proc "\n\n")))
 
 (defun ac-clang-send-reparse-request (proc)
-  (if (eq (process-status "clang-complete") 'run)
+  (if (eq (process-status proc) 'run)
       (save-restriction
 	(widen)
 	(process-send-string proc "SOURCEFILE\n")
@@ -460,7 +460,7 @@ This variable will typically contain include paths, e.g., (\"-I~/MyProject\" \"-
          (message "`ac-clang-cflags' should be a list of strings")))
 
 (defun ac-clang-send-shutdown-command (proc)
-  (if (eq (process-status "clang-complete") 'run)
+  (if (eq (process-status proc) 'run)
     (process-send-string proc "SHUTDOWN\n"))
   )
 
@@ -615,6 +615,7 @@ This variable will typically contain include paths, e.g., (\"-I~/MyProject\" \"-
   (ac-clang-send-reparse-request ac-clang-completion-process)
 
   (add-hook 'kill-buffer-hook 'ac-clang-shutdown-process nil t)
+  (add-hook 'before-revert-hook 'ac-clang-shutdown-process nil t)
   (add-hook 'before-save-hook 'ac-clang-reparse-buffer)
 
   (local-set-key (kbd ".") 'ac-clang-async-autocomplete-autotrigger)

--- a/makefile.mk
+++ b/makefile.mk
@@ -7,6 +7,12 @@ vpath %.d $(DEPENDENCY_PATH)
 vpath %.o $(OBJECT_PATH)
 
 
+prefix			= /usr/local
+exec_prefix 	= ${prefix}
+bindir			= ${exec_prefix}/bin
+PROGRAM_EXEC	= $(bindir)/$(PROGRAM_NAME)
+
+
 ## default .o and .dep path and program name
 OBJECT_PATH     ?= obj
 DEPENDENCY_PATH ?= dep
@@ -48,6 +54,12 @@ $(DEPENDENCY_PATH)/%.d: %.c
 	rm -f $@.$$$$
 
 
-.PHONY: clean build
+.PHONY: clean build install uninstall
 clean:
 	rm -f $(object-list) $(dependency-list)
+
+install: $(PROGRAM_NAME)
+	cp -f $(PROGRAM_NAME) $(bindir)
+
+uninstall: clean
+	rm -f $(PROGRAM_EXEC)


### PR DESCRIPTION
hi, i'm yaruopooner.
sorry, my English is poor.
- makefile.mk
  install/uninstall support
- auto-complete-clang-async.el
  1. The current version, the process will increase per call revert-buffer.
     
     issue is revert-buffer exec order.
     - don't execute kill-buffer-hook
     - all buffer local variables clear
     - execute c-mode-common-hook
  2. check name is bad  (process-status)
     
     When you open multiple buffers ...
     process-name is
     "clang-complete", "clang-complete< 1 >", "clang-complete< 2 >"......
     "clang-complete" is always check.
     but "clang-complete< \* >" is always ignore.
     Bug generated by this.
     process don't shutdown.
     process increase.
