### PR TITLE
Prepend the object path to .o files in generated dependency rules.

### DIFF
--- a/makefile.mk
+++ b/makefile.mk
@@ -49,9 +49,7 @@ $(OBJECT_PATH)/%.o: %.c
 
 $(DEPENDENCY_PATH)/%.d: %.c
 	@mkdir -p $(DEPENDENCY_PATH)
-	@$(CC) -M $(CFLAGS) $< > $@.$$$$;			\
-	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@;	\
-	rm -f $@.$$$$
+	@$(CC) -M $(CFLAGS) -MT $(OBJECT_PATH)/$(*F).o -MT $@ -MF $@ $<
 
 
 .PHONY: clean build install uninstall


### PR DESCRIPTION
The makefile was generating dependency rules which did not include the directory
part of the object filenames. This caused a problem where the project would not
be rebuilt if only the header files changed.

This commit fixes that by correctly specifying the name of the object files in
the dependency generation rule. At the same time, it simplifies the dependency
generation rule, by passing extra options to the compiler so it generates the
exact file we want. This means we no longer need to use sed to rewrite the
dependency files.

This addresses Golevka/emacs-clang-complete-async#40.
