### PR TITLE
Fix an error expanding arguments for overridden methods in C++.

### DIFF
--- a/auto-complete-clang-async.el
+++ b/auto-complete-clang-async.el
@@ -241,7 +241,8 @@ set new cflags for ac-clang from shell command output"
       (when (string-match "\\[#\\(.*\\)#\\]" s)
         (setq ret-t (match-string 1 s)))
       (setq s (replace-regexp-in-string "\\[#.*?#\\]" "" s))
-      (cond ((string-match "^\\([^(<]*\\)\\(:.*\\)" s)
+      (cond ((and (eq major-mode 'objc-mode)
+                  (string-match "^\\([^(<]*\\)\\(:.*\\)" s))
              (setq fn (match-string 1 s)
                    args (match-string 2 s))
              (push (propertize (ac-clang-clean-document args) 'ac-clang-help ret-t


### PR DESCRIPTION
When returning a completion for a method which is implemented in a base class,
the name of the class where the method was declared is included, so that instead
of:

COMPLETION: what : [#const char *#]what() const

we receive:

COMPLETION: what : [#const char *#]Implementation::what() const

The extra semi-colons after the class name caused this completion to match a
regexp which was added in hara/auto-complete-clang@4939442 (and merged in
Golevka/emacs-clang-complete-async@3176ea3) to support Objective C. In this
case, the argument list in the above example would be determined to be ":what()
const" rather than just "()". This commit fixes the issue by avoiding that
regexp unless we are in Objective C mode.

This fixes Golevka/emacs-clang-complete-async#39.
