### PR TITLE
Add ac-clang-jump-* and corresponding clang-complete code.

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,6 +11,7 @@ This extension is not implemented in pure elisp, it is made up of a client part
 (clang-complete binary, written in C), they work cooperately in asynchonous
 client-server fashion.
 
+
 * Experimental Feature - On the fly syntax checking
 
 An experimental feature is added to this branch --- running
@@ -18,6 +19,19 @@ An experimental feature is added to this branch --- running
 
 [[https://github.com/Golevka/emacs-clang-complete-async/raw/master/screenshots/syntax_check.png]]
 
+
+* Experimental Feature - Jump to declaration and definition
+
+You can now jump to either the declaration or the definition of the
+element your cursor is on.
+
+To jump to the definition, use =ac-clang-jump-definition=.
+
+To jump to the declaration, use =ac-clang-jump-declaration=.
+
+To jump to the definition, if it's available, otherwise to the declaration, use =ac-clang-jump-smart=.
+
+To pop the jump stack and go back to a previous location, use =ac-clang-jump-back=.
 
 * Setup
 
@@ -38,7 +52,11 @@ clang-complete executable to ~/.emacs.d/, and add the following code to your
   (setq ac-clang-complete-executable "~/.emacs.d/clang-complete")
   (setq ac-sources '(ac-source-clang-async))
   (ac-clang-launch-completion-process)
-)
+
+  ;; Optional keybindings
+  (define-key ac-mode-map (kbd "M-.") 'ac-clang-jump-smart)
+  (define-key ac-mode-map (kbd "M-,") 'ac-clang-jump-back)
+  (define-key ac-mode-map (kbd "C-c `") 'ac-clang-syntax-check))
 
 (defun my-ac-config ()
   (add-hook 'c-mode-common-hook 'ac-cc-mode-setup)

--- a/src/msg_callback.h
+++ b/src/msg_callback.h
@@ -38,6 +38,27 @@ void completion_AcceptRequest(completion_Session *session, FILE *fp);
         source_length:[#src_length#]
         <# SOURCE CODE #>
 
+   DECLARATION: Get location of declaration at point
+   Message format:
+        row:[#row#]
+        column:[#column#]
+        source_length:[#src_length#]
+        <# SOURCE CODE #>
+
+   DECLARATION: Get location of definition at point
+   Message format:
+        row:[#row#]
+        column:[#column#]
+        source_length:[#src_length#]
+        <# SOURCE CODE #>
+
+   SMARTJUMP: Get location of definition at point.  If that fails, get the declaration.
+   Message format:
+        row:[#row#]
+        column:[#column#]
+        source_length:[#src_length#]
+        <# SOURCE CODE #>
+
    SHUTDOWN: Shut down the completion server (this program)
    [no message body]
 */
@@ -48,6 +69,9 @@ void completion_doSourcefile(completion_Session *session, FILE *fp);   /* SOURCE
 void completion_doCmdlineArgs(completion_Session *session, FILE *fp);  /* CMDLINEARGS */
 void completion_doReparse(completion_Session *session, FILE *fp);      /* REPARSE */
 void completion_doSyntaxCheck(completion_Session *session, FILE *fp);  /* SYNTAXCHECK */
+void completion_doDeclaration(completion_Session *session, FILE *fp);  /* DECLARATION */
+void completion_doDefinition(completion_Session *session, FILE *fp);   /* DEFINITION */
+void completion_doSmartJump(completion_Session *session, FILE *fp);   /* SMARTJUMP */
 void completion_doShutdown(completion_Session *session, FILE *fp);     /* SHUTDOWN */
 
 

--- a/src/msg_dispatcher.c
+++ b/src/msg_dispatcher.c
@@ -18,6 +18,9 @@ __command_dispatch_table[] =
     {"SOURCEFILE",   completion_doSourcefile},
     {"CMDLINEARGS",  completion_doCmdlineArgs},
     {"SYNTAXCHECK",  completion_doSyntaxCheck},
+    {"DECLARATION",  completion_doDeclaration},
+    {"DEFINITION",   completion_doDefinition},
+    {"SMARTJUMP",    completion_doSmartJump},
     {"REPARSE",      completion_doReparse},
     {"SHUTDOWN",     completion_doShutdown}
 };


### PR DESCRIPTION
Also added a ac-clang-set-prefix-header-header, so one can -include-pth as well as -include-pch.  Sorry, that sneaked in there.
