### PR TITLE
Added rpath linker option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OBJECT_PATH     := ./src/obj
 PROGRAM_NAME    := clang-complete
 LLVM_CONFIG     := llvm-config
 
-LDLIBS := $(shell $(LLVM_CONFIG) --ldflags) -lclang
+LDLIBS := $(shell $(LLVM_CONFIG) --ldflags) -lclang -Wl,-rpath,$(shell $(LLVM_CONFIG) --libdir)
 CFLAGS += -std=c99 $(shell $(LLVM_CONFIG) --cflags) -Wall -Wextra -pedantic -O3
 
 


### PR DESCRIPTION
Now we don't have to edit LD_LIBRARY_PATH or /etc/ld.so.conf
if libclang.so is placed in non-default directory.
