### PR TITLE
Explicitly include <stdio.h>

### DIFF
--- a/src/completion.h
+++ b/src/completion.h
@@ -1,7 +1,7 @@
 #ifndef _COMPLETION_SESSION_H_
 #define _COMPLETION_SESSION_H_
 
-
+#include <stdio.h>
 #include <clang-c/Index.h>
 
 


### PR DESCRIPTION
I was getting compile errors with `FILE` as an undefined symbol without `<stdio.h>` explicitly included. Of course, this could be my error rather than yours, so here's my compiler info:

```
$ cc -v
clang version 3.5.0 (trunk 203549)
Target: x86_64-apple-darwin13.1.0
Thread model: posix
```

```
$ llvm-config --cflags
-I/usr/local/llvm/include  -DNDEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -O3  -fno-common
```

This is a relatively 'vanilla' version of `clang` built from source, on OS X Mavericks.
