### PR TITLE
Add --libdir to LDLIBS to fix build on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OBJECT_PATH     := ./src/obj
 PROGRAM_NAME    := clang-complete
 LLVM_CONFIG     := llvm-config
 
-LDLIBS := $(shell $(LLVM_CONFIG) --ldflags) -lclang
+LDLIBS := $(shell $(LLVM_CONFIG) --ldflags) -lclang -rpath $(shell ($LLVM_CONFIG) --libdir)
 CFLAGS += -std=c99 $(shell $(LLVM_CONFIG) --cflags) -Wall -Wextra -pedantic -O3
 
 


### PR DESCRIPTION
This fixes the following error that occurs when clang-complete is built
against brew-installed llvm-3.5

dyld: Library not loaded: @rpath/libLLVM-3.5.dylib
  Referenced from: /usr/local/opt/llvm/lib/libclang.dylib
  Reason: image not found
