### PR TITLE
Fix C++ parent class method completion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEPENDENCY_PATH := ./src/dep
 OBJECT_PATH     := ./src/obj
 
 PROGRAM_NAME    := clang-complete
-LLVM_CONFIG     := llvm-config
+LLVM_CONFIG     := llvm-config-3.8
 
 LDLIBS := $(shell $(LLVM_CONFIG) --ldflags) -lclang
 CFLAGS += -std=c99 $(shell $(LLVM_CONFIG) --cflags) -Wall -Wextra -pedantic -O3

--- a/auto-complete-clang-async.el
+++ b/auto-complete-clang-async.el
@@ -241,7 +241,12 @@ set new cflags for ac-clang from shell command output"
       (when (string-match "\\[#\\(.*\\)#\\]" s)
         (setq ret-t (match-string 1 s)))
       (setq s (replace-regexp-in-string "\\[#.*?#\\]" "" s))
-      (cond ((string-match "^\\([^(<]*\\)\\(:.*\\)" s)
+      (cond ((string-match "^.*::\\([^(<]*\\)\\(.*\\)" s)
+             (setq fn (match-string 1 s)
+                   args (match-string 2 s))
+             (push (propertize (ac-clang-clean-document args) 'ac-clang-help ret-t
+                               'raw-args args) candidates))
+            ((string-match "^\\([^(<]*\\)\\(:.*\\)" s)
              (setq fn (match-string 1 s)
                    args (match-string 2 s))
              (push (propertize (ac-clang-clean-document args) 'ac-clang-help ret-t


### PR DESCRIPTION
For e.g., in Qt, QFile has a close() method inherited:

```
void QFileDevice::close();
void QIODevice::close();
```

Now, when close() is completed, it turns out to be close:close(),
because :close() instead of () is incorrectly parsed as the argument.

Signed-off-by: Bao Haojun baohaojun@gmail.com
